### PR TITLE
[Nix] Configure ANDROID_HOME

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -1,0 +1,4 @@
+{
+  config.allowUnfree = true;
+  config.android_sdk.accept_license = true;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,10 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
+        config = import ./config.nix // {
+          inherit system;
+        };
+        pkgs = import nixpkgs config;
       in {
         devShells.default = import ./shell.nix { inherit pkgs; };
       }

--- a/shell.nix
+++ b/shell.nix
@@ -17,7 +17,22 @@ let
   ];
 
   # needed for android target
-  androidsdk = pkgs.androidenv.androidPkgs.androidsdk;
+  android = pkgs.androidenv.composeAndroidPackages {
+    toolsVersion = null;
+    includeEmulator = false;
+    platformVersions = [ "34" ];
+    includeSources = false;
+    includeSystemImages = false;
+    systemImageTypes = [];
+    abiVersions = [];
+    cmakeVersions = [];
+    includeNDK = false;
+    ndkVersions = [];
+    useGoogleAPIs = false;
+    useGoogleTVAddOns = false;
+    includeExtras = [];
+  };
+  inherit (android) androidsdk;
 
   gradle = pkgs.writeShellApplication {
     name = "gradle";

--- a/shell.nix
+++ b/shell.nix
@@ -16,6 +16,9 @@ let
     pkgs.libGL
   ];
 
+  # needed for android target
+  androidsdk = pkgs.androidenv.androidPkgs.androidsdk;
+
   gradle = pkgs.writeShellApplication {
     name = "gradle";
     text = ''
@@ -27,7 +30,7 @@ let
       PATH=${bin-path} \
       LD_LIBRARY_PATH=${ld-library-path} \
       JAVA_HOME=${pkgs.jre} \
-      ANDROID_HOME=${pkgs.androidenv.androidPkgs.androidsdk}/libexec/android-sdk \
+      ANDROID_HOME=${androidsdk}/libexec/android-sdk \
       exec "./gradlew" -PnixManaged=true "$@"
     '';
   };

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> (import ./config.nix) }:
 
 let
   bin-path = pkgs.lib.makeBinPath [
@@ -27,6 +27,7 @@ let
       PATH=${bin-path} \
       LD_LIBRARY_PATH=${ld-library-path} \
       JAVA_HOME=${pkgs.jre} \
+      ANDROID_HOME=${pkgs.androidenv.androidPkgs.androidsdk}/libexec/android-sdk \
       exec "./gradlew" -PnixManaged=true "$@"
     '';
   };


### PR DESCRIPTION
Problem: Cannot run `gradle test` in `nix-develop` or `nix shell`.
Solution: Add dependency on `android-sdk`.

TODO:

- [ ] should we accept the license like this?
- [x] can we compose a smaller SDK using [composeAndroidPackages](https://nixos.org/manual/nixpkgs/unstable/#deploying-an-android-sdk-installation-with-plugins)? (done in 25ae043 now)

Remaining Impact:

```
$ nix store diff-closures ./without-android-sdk ./with-android-sdk

android-sdk-build-tools: ∅ → 34.0.0, +158347.2 KiB
android-sdk-patcher: ∅ → 1, +1936.1 KiB
android-sdk-platform-tools: ∅ → 35.0.1, +17235.3 KiB
android-sdk-platforms: ∅ → 34, +99515.2 KiB
androidenv-android-sdk: ∅ → ε
androidsdk: ∅ → ε, +153422.8 KiB
ncurses-abi5-compat: ∅ → 6.4.20221231, +3574.6 KiB
openjdk: ∅ → 11.0.23+9, +529988.7 KiB
```

It looks like we have two JDKs now which is a bit annoying:

```
$ nix path-info --recursive --size --human-readable ./with-android-sdk | grep jdk
/nix/store/bk3x3ia7gxqic1jgr3dz05gwi8zw671y-openjdk-21+35                           	 566.8M
/nix/store/9p4zzak1xgqg0z2vf792l899fm9xv23l-openjdk-11.0.23+9                       	 517.6M
```

I tried using only `pkgs.jdk11` but that doesn't work because `gradle` needs at least JDK 17. I don't know how to configure the Android SDK to use a different JDK (nor whether it would work with JDK 17 or even 21).